### PR TITLE
Remove moz border radius properties

### DIFF
--- a/app/assets/stylesheets/eval.css
+++ b/app/assets/stylesheets/eval.css
@@ -193,7 +193,6 @@ table.popup th {
 	border-style: none;
 	border-color: gray;
 	background-color: rgb(255, 255, 240);
-	-moz-border-radius: ;
 }
 table.popup td {
 	border-width: 1px;
@@ -201,7 +200,6 @@ table.popup td {
 	border-style: none;
 	border-color: gray;
 	background-color: rgb(255, 255, 240);
-	-moz-border-radius: ;
 }
 
 .gx-zoomslider {

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -66,7 +66,6 @@ class HomeController < ApplicationController
 
     begin
       doc = Nokogiri::XML(open(base_wms_url))
-      p doc
       render xml: doc
     rescue Exception => e
       render nothing: true, status: :bad_request


### PR DESCRIPTION
There are a couple of `moz-border-radius` properties that have been incorrectly
set and are causing asset compiliation errors when we try to deploy to PaaS. As
this property is no longer necessary in more recent versions of Firefox we
remove them from our CSS.